### PR TITLE
Fix the autoload cookie (#6)

### DIFF
--- a/selectric-mode.el
+++ b/selectric-mode.el
@@ -34,7 +34,6 @@
       (start-process "*Messages*" nil "aplay" (format "%sselectric-type.wav"
                                                        selectric-files-path))))
 
-;;;autoload
 (defun selectric-move-sound ()
   (if (eq system-type 'darwin)
       (start-process "*Messages*" nil "afplay" (format "%sselectric-move.wav"
@@ -42,6 +41,7 @@
       (start-process "*Messages*" nil "aplay" (format "%sselectric-move.wav"
                                                        selectric-files-path))))
 
+;;;###autoload
 (define-minor-mode selectric-mode
   "Toggle Selectric mode.
 Interactively with no argument, this command toggles the mode.


### PR DESCRIPTION
The autoload cookie should be before the minor mode definition, not
before electric-move-sound. Move it there, and fix its syntax.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
