### PR TITLE
don't ping in minibuffer

### DIFF
--- a/selectric-mode.el
+++ b/selectric-mode.el
@@ -38,8 +38,9 @@
   (if (eq system-type 'darwin)
       (make-sound (format "%sselectric-type.wav" selectric-files-path))
       (make-sound (format "%sselectric-type.wav" selectric-files-path)))
-  (if (= (current-column) (current-fill-column))
-      (make-sound (format "%sping.wav" selectric-files-path))))
+  (unless (minibufferp)
+    (if (= (current-column) (current-fill-column))
+        (make-sound (format "%sping.wav" selectric-files-path)))))
 
 (defun selectric-move-sound ()
   "Carriage movement sound."


### PR DESCRIPTION
Disables the _ping_ sound in minibuffer which I found confusing. Fill column doesn't mean anything in minibuffer which we usually use for switching between files, buffers etc..
