### PR TITLE
Simplify the mode and make it work correctly with Evil.

### DIFF
--- a/selectric-mode.el
+++ b/selectric-mode.el
@@ -28,81 +28,49 @@
 
 ;;; Code:
 
-(defconst selectric-files-path (file-name-directory load-file-name))
+(defconst selectric-files-path (file-name-directory load-file-name)
+  "Directory containing the typewriter audio files.")
 
-(defvar selectric-mode-map (make-sparse-keymap) "Selectric mode's keymap.")
+(defvar-local selectric-last-state nil
+  "The last (buffer-size . point) seen by `selectric-mode'.")
 
-(defvar selectric-affected-bindings-list
-  '("<up>" "<down>" "<right>" "<left>" "DEL" "C-d")
-  "The keys we'll override.")
+(defun selectric-play (sound-file)
+  "Play sound from file SOUND-FILE using platform-appropriate program."
+  (let ((absolute-path (expand-file-name sound-file selectric-files-path)))
+    (if (eq system-type 'darwin)
+        (start-process "*Messages*" nil "afplay" absolute-path)
+      (start-process "*Messages*" nil "aplay" absolute-path))))
 
-(defvar selectric-saved-bindings (make-hash-table :test 'equal)
-  "The hash map where we'll save the key bindings.")
-
-(defun selectric-save-bindings (keys hashmap)
-  "Save the key-bindings of the keys in KEYS into HASHMAP."
-  (dolist (key keys)
-    (puthash key (key-binding (kbd key)) hashmap)))
-
-(defun selectric-make-sound (sound-file-name)
-  "Play sound from file SOUND-FILE-NAME using platform-appropriate program."
-  (if (eq system-type 'darwin)
-      (start-process "*Messages*" nil "afplay" sound-file-name)
-    (start-process "*Messages*" nil "aplay" sound-file-name)))
-
-(defun selectric-type-sound ()
+(defun selectric-type ()
   "Make the sound of the printing element hitting the paper."
-  (progn
-    (selectric-make-sound (format "%sselectric-type.wav" selectric-files-path))
-    (unless (minibufferp)
-      (if (= (current-column) (current-fill-column))
-          (selectric-make-sound (format "%sping.wav" selectric-files-path))))))
+  (selectric-play "selectric-type.wav")
+  (when (= (current-column) (current-fill-column))
+    (selectric-play "ping.wav")))
 
-(defun selectric-move-sound ()
+(defun selectric-move ()
   "Make the carriage movement sound."
-  (selectric-make-sound (format "%sselectric-move.wav" selectric-files-path)))
+  (selectric-play "selectric-move.wav"))
+
+(defun selectric-post-command ()
+  "Added to `post-command-hook' to decide what sound to play."
+  (unless (minibufferp)
+    (let ((last-size (car selectric-last-state))
+          (last-point (cdr selectric-last-state)))
+      (setf selectric-last-state (cons (buffer-size) (point)))
+      (cond ((not (eql (buffer-size) last-size)) (selectric-type))
+            ((not (eql (point) last-point)) (selectric-move))))))
 
 ;;;###autoload
 (define-minor-mode selectric-mode
   "Toggle Selectric mode.
-Interactively with no argument, this command toggles the mode.  A
-positive prefix argument enables the mode, any other prefix
-argument disables it.  From Lisp, argument omitted or nil enables
-the mode, `toggle' toggles the state.
-
 When Selectric mode is enabled, your Emacs will sound like an IBM
 Selectric typewriter."
   :global t
-  ;; The initial value.
-  :init-value nil
-  ;; The indicator for the mode line.
-  :lighter " Selectric"
   :group 'selectric
-  :keymap selectric-mode-map
-
   (if selectric-mode
-      (progn
-        ; Save the current bindings into a map
-        (selectric-save-bindings
-         selectric-affected-bindings-list selectric-saved-bindings)
-
-        ; Override the key bindings
-        (dolist (key selectric-affected-bindings-list)
-          (define-key selectric-mode-map (kbd key)
-            (lambda ()
-              (interactive)
-              (prog2
-                (selectric-move-sound)
-                (call-interactively (gethash key selectric-saved-bindings))))))
-
-        (add-hook 'post-self-insert-hook 'selectric-type-sound)
-        ; (global-set-key [left] (noisy-move 'left-char))
-        (selectric-type-sound))
-    (progn
-      ; Whem we exit the mode, the original map is restored.
-      (remove-hook 'post-self-insert-hook 'selectric-type-sound)
-      (selectric-move-sound)))
-  )
+      (add-hook 'post-command-hook 'selectric-post-command)
+    (remove-hook 'post-command-hook 'selectric-post-command)))
 
 (provide 'selectric-mode)
+
 ;;; selectric-mode.el ends here


### PR DESCRIPTION
I don't expect you to merge this, especially since I made some opinionated changes. I'm using this more to communicate an alternate way to attach sounds to the right sorts of commands. The current version makes assumptions -- or at least requires configuration -- about the current movement bindings, and it interferes with some of the self-insert bindings, generally breaking Evil/Spacemacs (#20). Unfortunately there's not really any way for the mode to discover the user's configuration and hook the right things.

The alternate approach in this PR is to hook `post-command-hook` and observe changes to the buffer's state: specifically its size and point position. That way it doesn't matter what commands are bound to what keys. If the buffer changes size, play a typing sound. If instead the point moved, play a movement sound. This also avoids the whole mess with the hash table.

The hook function could definitely use more smarts. For example, it can't tell the difference between yanking/pasting and typing. They're both just changes to the size of the buffer. It also makes a huge racket when macros are played back (and for Evil's dot `.` command).
