### PR TITLE
Avoid re-evaluation of prior bindings when re-enabling.

### DIFF
--- a/selectric-mode.el
+++ b/selectric-mode.el
@@ -42,7 +42,7 @@
 (defun selectric-save-bindings (keys hashmap)
   "Save the key-bindings of the keys in KEYS into HASHMAP."
   (dolist (key keys)
-    (puthash key (key-binding (kbd key)) hashmap)))
+    (puthash key (global-key-binding (kbd key)) hashmap)))
 
 (defun selectric-make-sound (sound-file-name)
   "Play sound from file SOUND-FILE-NAME using platform-appropriate program."


### PR DESCRIPTION
As it is in master, first enable of selectric-mode works correctly, but in subsequent enables the prior bindings are returned by `key-binding`, causing an infinite loop of `call-interactively`.
This pull solves it (fixing #19 and #23).
Undefining the bindings in `selectric-map` as [suggested]([https://github.com/rbanffy/selectric-mode/issues/19#issue-210556701]) by @wombatzus does not work, as once the minor mode has been made active the keymap is copied to `minor-mode-map-alist`.